### PR TITLE
Force Rect/Size/Point instead of tuples

### DIFF
--- a/tests/vaitk/core/test_Point.py
+++ b/tests/vaitk/core/test_Point.py
@@ -1,6 +1,3 @@
-import pytest
-from traitlets import TraitError
-
 from vaitk import core
 
 
@@ -8,11 +5,6 @@ def test_initialisation():
     v = core.Point(x=4, y=5)
     assert v.x == 4
     assert v.y == 5
-
-
-def test_invalid_arguments():
-    with pytest.raises(TraitError):
-        core.Point(x="foo", y=5)
 
 
 def test_sum():
@@ -29,8 +21,3 @@ def test_difference():
     vres = v1-v2
     assert vres.x, 2
     assert vres.y, 3
-
-
-def test_as_tuple():
-    v1 = core.Point(x=4, y=5)
-    assert v1.as_tuple() == (4, 5)

--- a/tests/vaitk/core/test_Rect.py
+++ b/tests/vaitk/core/test_Rect.py
@@ -1,9 +1,8 @@
-from vaitk import core
-from vaitk.core import Size, Point
+from vaitk.core import Rect, Size, Point
 
 
-def test_initialization():
-    r = core.Rect(Point(2, 3), Size(4, 5))
+def test_initialization_from_point_and_size():
+    r = Rect(Point(2, 3), Size(4, 5))
 
     assert r.x == 2
     assert r.y == 3
@@ -34,40 +33,23 @@ def test_initialization():
     assert r.bottom == 7
 
 
-def test_initialization_from_tuple():
-    r = core.Rect((1, 2), (3, 4))
-    assert r.size.as_tuple() == (3, 4)
-    assert r.top_left.as_tuple() == (1, 2)
-
-
-def test_from_tuple():
-    r = core.Rect.from_tuple((1, 2, 3, 4))
-    assert r.size.as_tuple() == (3, 4)
-    assert r.top_left.as_tuple() == (1, 2)
-
-
 def test_is_null():
-    r = core.Rect.from_x_y_width_height(2, 3, 4, 5)
+    r = Rect(Point(2, 3), Size(4, 5))
     assert not r.is_null()
 
-    r = core.Rect.from_x_y_width_height(2, 3, 0, 0)
+    r = Rect(Point(2, 3), Size(0, 0))
     assert r.is_null()
 
 
 def test_intersects():
-    assert core.Rect.from_x_y_width_height(0, 0, 18, 1).intersects(
-        core.Rect.from_x_y_width_height(4, 0, 142, 40))
-    assert not core.Rect.from_x_y_width_height(0, 0, 3, 3).intersects(
-        core.Rect.from_x_y_width_height(4, 4, 1, 1))
-
-
-def test_as_tuple():
-    r = core.Rect.from_x_y_width_height(2, 3, 4, 5)
-    assert r.as_tuple() == (2, 3, 4, 5)
+    assert Rect(Point(0, 0), Size(18, 1)).intersects(
+        Rect(Point(4, 0), Size(142, 40)))
+    assert not Rect(Point(0, 0), Size(3, 3)).intersects(
+        Rect(Point(4, 4), Size(1, 1)))
 
 
 def test_move_to():
-    r = core.Rect.from_x_y_width_height(2, 3, 4, 5)
+    r = Rect(Point(2, 3), Size(4, 5))
     r.move_to(Point(4, 5))
     assert r.x == 4
     assert r.y == 5

--- a/tests/vaitk/core/test_Size.py
+++ b/tests/vaitk/core/test_Size.py
@@ -6,7 +6,3 @@ def test_initialisation():
     assert v.height == 5
     assert v.width == 4
 
-
-def test_as_tuple():
-    v = core.Size(width=4, height=5)
-    assert v.as_tuple() == (4, 5)

--- a/tests/vaitk/core/test_Size.py
+++ b/tests/vaitk/core/test_Size.py
@@ -5,4 +5,3 @@ def test_initialisation():
     v = core.Size(width=4, height=5)
     assert v.height == 5
     assert v.width == 4
-

--- a/vaitk/core/Point.py
+++ b/vaitk/core/Point.py
@@ -16,11 +16,6 @@ class Point(HasTraits):
     def __init__(self, x, y):
         super().__init__(x=x, y=y)
 
-    @classmethod
-    def from_tuple(cls, t):
-        """Creates a Point from a 2-tuple with (x, y) coordinates"""
-        return cls(*t)
-
     def __add__(self, other):
         """
         Adds this point to another point "other".
@@ -38,7 +33,3 @@ class Point(HasTraits):
 
     def __str__(self):
         return f"{self.__class__.__name__}(x={self.x}, y={self.y})"
-
-    def as_tuple(self):
-        """Returns a tuple with the (x, y) coordinates"""
-        return self.x, self.y

--- a/vaitk/core/Rect.py
+++ b/vaitk/core/Rect.py
@@ -38,44 +38,12 @@ class Rect(HasTraits):
         Constructor.
 
         Args:
-            top_left: Point or tuple
+            top_left: Point
                 The top left coordinate of the rectangle
-            size: Size or tuple
+            size: Size
                 The size of the rectangle
         """
-        if isinstance(top_left, tuple):
-            top_left = Point.from_tuple(top_left)
-
-        if isinstance(size, tuple):
-            size = Size.from_tuple(size)
-
         super().__init__(top_left=top_left, size=size)
-
-    @classmethod
-    def from_x_y_width_height(cls, x, y, width, height):
-        """
-        Alternate constructor: creates the Rect from x y coordinates of
-        the top left corner, and from width and height of the rectangle.
-
-        Args:
-            x: int
-                The x coordinate of the top left corner
-            y: int
-                The y coordinate of the top left corner
-            width: int
-                The width of the rectangle
-            height: int
-                The height of the rectangle
-
-        Returns: Rect
-        """
-        top_left = Point(x, y)
-        size = Size(width, height)
-        return cls(top_left, size)
-
-    @classmethod
-    def from_tuple(cls, t):
-        return cls.from_x_y_width_height(*t)
 
     @property
     def x(self):
@@ -163,14 +131,6 @@ class Rect(HasTraits):
                 and self.right >= other.left
                 and self.top <= other.bottom
                 and self.bottom >= other.top)
-
-    def as_tuple(self):
-        """
-        Returns: tuple
-            A 4-tuple (x, y, width, height)
-
-        """
-        return self.x, self.y, self.width, self.height
 
     def __str__(self):
         return (f"Rect(x={self.x}, y={self.y}, "

--- a/vaitk/core/Size.py
+++ b/vaitk/core/Size.py
@@ -19,29 +19,5 @@ class Size(HasTraits):
         """
         super().__init__(width=width, height=height)
 
-    @classmethod
-    def from_tuple(cls, t):
-        """
-        Alternate constructor.
-        Creates a Size from a 2-tuple (width, height)
-
-        Args:
-            t: tuple
-                a 2-tuple (width, height)
-
-        Returns: Size
-
-        """
-        return cls(*t)
-
     def __str__(self):
         return f"Size(width={self.width}, height={self.height})"
-
-    def as_tuple(self):
-        """
-
-        Returns: tuple
-            A 2-tuple (width, height)
-
-        """
-        return self.width, self.height


### PR DESCRIPTION
Enforce the use of the classes, rather than the tuple, to ensure proper values.
